### PR TITLE
add lazy encoding initialization for ClientResponse

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -712,6 +712,7 @@ class ClientResponse(HeadersMixin):
         self._real_url = url
         self._url = url.with_fragment(None)
         self._body: Optional[bytes] = None
+        self._encoding: Optional[str] = None
         self._writer: Optional[asyncio.Task[None]] = writer
         self._continue = continue100  # None by default
         self._closed = True
@@ -1005,6 +1006,9 @@ class ClientResponse(HeadersMixin):
         return self._body
 
     def get_encoding(self) -> str:
+        if self._encoding:
+            return self._encoding
+            
         ctype = self.headers.get(hdrs.CONTENT_TYPE, "").lower()
         mimetype = helpers.parse_mimetype(ctype)
 
@@ -1030,6 +1034,8 @@ class ClientResponse(HeadersMixin):
         if not encoding:
             encoding = "utf-8"
 
+        self._encoding = encoding
+        
         return encoding
 
     async def text(self, encoding: Optional[str] = None, errors: str = "strict") -> str:


### PR DESCRIPTION
It will speed up behaviour in case when `text()` or `json()` methods are called several times for same response.

So '_body' optimization does.

When `text()` is called without encoding and several times we spent a lot of time for encoding 'detect`ion in some cases.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
